### PR TITLE
Add basic way to provide strategies

### DIFF
--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -1,0 +1,31 @@
+use proptest::prelude::prop_compose;
+use proptest_attr_macro::proptest;
+
+#[proptest(33u8..100u8)]
+fn inline_strategy(x: u8) {
+    assert!(x >= 33 && x < 100)
+}
+
+#[proptest(up_to(43))]
+fn predefined_strategy(x: u8) {
+    assert!(x <= 42)
+}
+
+#[proptest(up_to(43), up_to(100))]
+fn multiple_strategies(x: u8, y: u8) {
+    assert!(x <= 42 && y < 100)
+}
+
+#[proptest(1u8..5u8, 6u8..10u8)]
+fn multiple_inline_strategies(x: u8, y: u8) {
+    assert!(x >= 1 && x < 5);
+    assert!(y >= 6 && y < 10);
+}
+
+prop_compose! {
+  fn up_to(max_integer: u8)
+                       (integer in 0..max_integer)
+                       -> u8 {
+    integer
+  }
+}

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -3,17 +3,18 @@ use proptest_attr_macro::proptest;
 
 #[proptest(33u8..100u8)]
 fn inline_strategy(x: u8) {
-    assert!(x >= 33 && x < 100)
+    assert!(x >= 33 && x < 100);
 }
 
-#[proptest(up_to(43))]
+#[proptest(range(1, 5))]
 fn predefined_strategy(x: u8) {
-    assert!(x <= 42)
+    assert!(x >= 1 && x < 5);
 }
 
-#[proptest(up_to(43), up_to(100))]
+#[proptest(range(5, 7), range(10, 20))]
 fn multiple_strategies(x: u8, y: u8) {
-    assert!(x <= 42 && y < 100)
+    assert!(x >= 5 && x < 7);
+    assert!(y >= 10 && y < 20);
 }
 
 #[proptest(1u8..5u8, 6u8..10u8)]
@@ -23,8 +24,8 @@ fn multiple_inline_strategies(x: u8, y: u8) {
 }
 
 prop_compose! {
-  fn up_to(max_integer: u8)
-                       (integer in 0..max_integer)
+  fn range(from: u8, to: u8)
+                       (integer in from..to)
                        -> u8 {
     integer
   }

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -1,7 +1,7 @@
 use proptest::prelude::prop_compose;
 use proptest_attr_macro::proptest;
 
-#[proptest(33u8..100u8)]
+#[proptest(33..100u8)]
 fn inline_strategy(x: u8) {
     assert!(x >= 33 && x < 100);
 }
@@ -17,7 +17,7 @@ fn multiple_strategies(x: u8, y: u8) {
     assert!(y >= 10 && y < 20);
 }
 
-#[proptest(1u8..5u8, 6u8..10u8)]
+#[proptest(1..5u8, 6..10u8)]
 fn multiple_inline_strategies(x: u8, y: u8) {
     assert!(x >= 1 && x < 5);
     assert!(y >= 6 && y < 10);


### PR DESCRIPTION
## TODOs
  - [ ] Fix current limitation: If one defines strategies they have to be defined for every argument
  - [ ] Define strategy by name like `#[proptest( x = 1u8..5u8)]`
  - [ ] Update documentation